### PR TITLE
feature: Implement global capture filter

### DIFF
--- a/cmd/k8s.go
+++ b/cmd/k8s.go
@@ -90,7 +90,7 @@ Start a kubernetes packet kpture running these steps:
 
 		kptureID := uuid.New().String()
 
-		agentOpts := k8s.LoadAgentOpts(k8s.WithAgentUUID(kptureID), k8s.WithAgentSnapLen(-1))
+		agentOpts := k8s.LoadAgentOpts(k8s.WithAgentUUID(kptureID), k8s.WithAgentSnapLen(-1), k8s.WithAgentCaptureFilter(capturefilter))
 		proxyOpts := k8s.LoadProxyOpts(k8s.WithProxyUUID(kptureID))
 
 		writer, err := newpcapWriter(cmd, pods, uint32(agentOpts.SnapshotLen))
@@ -203,6 +203,7 @@ func init() {
 	packetsCmd.Flags().BoolVarP(&all, "all", "a", false, "Capture from all pods in the selected namespace")
 	packetsCmd.Flags().BoolVarP(&raw, "raw", "r", false, "Print raw packet to stdout (for tshark/wireshark)")
 	packetsCmd.Flags().StringVarP(&output, "output", "o", "random-kpture-id", "output folder")
+	packetsCmd.Flags().StringVarP(&capturefilter, "filter", "f", "", "capture filter")
 	packetsCmd.Flags().BoolVarP(&split, "split", "s", true, "split pcap files per pod")
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,11 +10,12 @@ import (
 )
 
 var (
-	raw       bool
-	output    string
-	namespace string
-	all       bool
-	split     bool
+	raw           bool
+	output        string
+	namespace     string
+	all           bool
+	capturefilter string
+	split         bool
 )
 
 // RootCmd represents the base command when called without any subcommands.

--- a/pkg/k8s/ephemeral.go
+++ b/pkg/k8s/ephemeral.go
@@ -132,6 +132,7 @@ func debugPod(pod *v1.Pod, name string, opts AgentOpts) *v1.Pod {
 		fmt.Sprintf("-t%s", opts.TargetIP),
 		fmt.Sprintf("-l%d", opts.SnapshotLen),
 		fmt.Sprintf("-p%d", opts.TargetPort),
+		fmt.Sprintf("-f%s", opts.Filter),
 	}
 	p := true
 	f := false
@@ -139,7 +140,6 @@ func debugPod(pod *v1.Pod, name string, opts AgentOpts) *v1.Pod {
 	ec := &v1.EphemeralContainer{
 		EphemeralContainerCommon: v1.EphemeralContainerCommon{
 			Name: name,
-
 			SecurityContext: &v1.SecurityContext{
 				RunAsUser: &user,
 				Capabilities: &v1.Capabilities{

--- a/pkg/k8s/options.go
+++ b/pkg/k8s/options.go
@@ -74,6 +74,7 @@ type AgentOpts struct {
 	TargetIP     string        // proxy endpoint address to send packet via gRPC
 	TargetPort   int           // proxy endpoint port to send packet via gRPC
 	UUID         string        // kpture uuid used in  ephemeral container name
+	Filter       string        // https://www.tcpdump.org/manpages/pcap_compile.3pcap.html
 	SetupTimeout time.Duration // timeout for ephemeral container injection
 }
 
@@ -115,6 +116,12 @@ func WithAgentDevice(n string) AgentOpt {
 func WithAgentPromiscuous(n bool) AgentOpt {
 	return func(o AgentOpts) AgentOpts {
 		o.Promiscuous = n
+		return o
+	}
+}
+func WithAgentCaptureFilter(n string) AgentOpt {
+	return func(o AgentOpts) AgentOpts {
+		o.Filter = n
 		return o
 	}
 }


### PR DESCRIPTION
Implement a capture filter that is used in all targeted capture pods:

Example :

```bash
kpture packets nginx-2  --filter "udp or tcp port 8080" --raw | tee session_10.pcap |  tshark --color -r -
```